### PR TITLE
Update README's autograder-py commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ need to update the:
 The autograder command line interface (cli) is [documented](https://github.com/eriq-augustine/autograder-py).  As a
 student in the class, the main commands you will use are:
 
--   `python3 -m autograder.cli.submit`: this will submit an assignment
+-   `python3 -m autograder.cli.submission.submit`: this will submit an assignment
     for a particular class and assignment.
--   `python3 -m autograder.cli.peek`: this will show you your last submission
--   `python3 -m autograder.cli.history`: this will show a summary of all
+-   `python3 -m autograder.cli.submission.peek`: this will show you your last submission
+-   `python3 -m autograder.cli.submission.history`: this will show a summary of all
     your past submission
--   `python3 -m autograder.cli.style`: this will check the style of a
+-   `python3 -m autograder.cli.util.style`: this will check the style of a
     particular assignment.

--- a/p0/README.md
+++ b/p0/README.md
@@ -39,7 +39,7 @@ When you are ready to submit,
     you can do so using the command:
 
 ```sh
-    python3 -m autograder.cli.submit buyLotsOfFruit.py shopSmart.py
+    python3 -m autograder.cli.submission.submit buyLotsOfFruit.py shopSmart.py
 ```
 
 This will take your `config.json`, `buyLotsOfFruit.py`, and `shopSmart.py` from your current directory and send them to the autograding server.    The autograderwill get your code and run a bunch of secret tests on it to assign you a grade.

--- a/p1/README.md
+++ b/p1/README.md
@@ -45,7 +45,7 @@ When you are ready to submit,
     you can do so using the command:
 
 ```sh
-    python3 -m autograder.cli.submit pacai/student/search.py pacai/student/searchAgents.py
+    python3 -m autograder.cli.submission.submit pacai/student/search.py pacai/student/searchAgents.py
 ```
 
 This will take your `config.json`, `pacai/student/search.py`, and `pacai/student/searchAgents.py` from your current directory

--- a/p2/README.md
+++ b/p2/README.md
@@ -45,7 +45,7 @@ When you are ready to submit,
     you can do so using the command:
 
 ```sh
-    python3 -m autograder.cli.submit pacai/student/multiagents.py
+    python3 -m autograder.cli.submission.submit pacai/student/multiagents.py
 ```
 
 This will take your `config.json` and `pacai/student/multiagents.py` from your current directory

--- a/p3/README.md
+++ b/p3/README.md
@@ -45,7 +45,7 @@ When you are ready to submit,
     you can do so using the command:
 
 ```sh
-    python3 -m autograder.cli.submit
+    python3 -m autograder.cli.submission.submit
     pacai/student/valueIterationAgent.py
     pacai/student/qlearningAgents.py pacai/student/analysis.py
 ```

--- a/p4/README.md
+++ b/p4/README.md
@@ -63,7 +63,7 @@ When you are ready to submit,
     you can do so using the command:
 
 ```sh
-    python3 -m autograder.cli.submit
+    python3 -m autograder.cli.submission.submit
     pacai/student/myTeam.py pacai/student/name.txt
 ```
 


### PR DESCRIPTION
Hello, I am a current CSE140 student!

As I was working on p0, I found that the current autograder.cli commands listed at the bottom of the main README.md are out of date, namely the following:

- python3 -m autograder.cli.submit
- python3 -m autograder.cli.peek
- python3 -m autograder.cli.history
- python3 -m autograder.cli.style

When I tried to submit my assignment with `python3 -m autograder.cli.submit`, I got: `No module named autograder.cli.submit`

I believe with the version listed in requirements.txt, autograder-py>=0.4.2, that these commands have moved and should be
- python3 -m autograder.cli.**submission**.submit
- python3 -m autograder.cli.**submission**.peek
- python3 -m autograder.cli.**submission**.history
- python3 -m autograder.cli.**util**.style

With these, I was able to use each of the commands. I posted about the first command on our Piazza but wanted to make this PR for visibility.

Thank you!